### PR TITLE
Harden devstack scripts for cross-platform compatibility

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   cafedebugdb:
     container_name: cafedebugdb

--- a/scripts/cafedebug-setup.sh
+++ b/scripts/cafedebug-setup.sh
@@ -1,170 +1,132 @@
-  #!/bin/bash
+#!/bin/bash
 set -euo pipefail
 
-# Source functions for colored output and utilities
-SCRIPT_DIR="$(dirname "$0")"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/functions.sh"
 
-# Define the root directory of the project (one level up from the script directory)
-  PROJECT_ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+init_script_paths "${BASH_SOURCE[0]}"
+resolve_compose_cmd || exit 1
+build_compose_files
 
-  # Read MySQL version from docker-compose.yml
-  MySQL_VERSION=$(grep -o 'mysql:[0-9]\+\.[0-9]\+' "$PROJECT_ROOT_DIR/docker-compose.yml" | cut -d':' -f2 || echo "8.0")
-  
-  echo_info "Using MySQL version $MySQL_VERSION from docker-compose.yml"
-  
-  ## Build list of compose files to use (root + optional api/ and svc/ fragments)
-  COMPOSE_FILES=("-f" "$PROJECT_ROOT_DIR/docker-compose.yml")
-  
-  # include svc/* docker-compose.yml fragments (e.g. svc/minio/docker-compose.yml)
-	for svc_file in "$PROJECT_ROOT_DIR"/svc/*/minio.yml; do
-	  if [ -f "$svc_file" ] && grep -q "^services:\|^services\s*:\s*$" "$svc_file"; then
-		COMPOSE_FILES+=("-f" "$svc_file")
-	  else
-		if [ -f "$svc_file" ]; then
-		  echo_info "Note: $svc_file exists but does not contain 'services:' — skipping inclusion"
-		fi
-	  fi
-	done
+MySQL_VERSION=$(grep -o 'mysql:[0-9]\+\.[0-9]\+' "${PROJECT_ROOT_DIR}/docker-compose.yml" | cut -d':' -f2 || echo "8.0")
+echo_info "Using MySQL version ${MySQL_VERSION} from docker-compose.yml"
 
-  # Start only core infra first (DB + MinIO), then start API after SQL seed.
-  echo "Starting core services using compose files: ${COMPOSE_FILES[*]}"
-  docker-compose "${COMPOSE_FILES[@]}" down || true
-  docker-compose "${COMPOSE_FILES[@]}" up -d cafedebugdb minio minio-mc cafedebug-api
-  echo_ok "Core services started successfully"
+echo "Starting core services using compose files: ${COMPOSE_FILES[*]}"
+compose down || true
+compose up -d cafedebugdb minio minio-mc
+echo_ok "Core services started successfully"
 
-  echo_info "Waiting for MySQL to complete initialization (this may take 1-2 minutes)..."
-  
-  # Wait for MySQL to be completely ready - not just ping-able
-  MAX_WAIT=180  # Increased timeout for full initialization
-  WAITED=0
-  echo "Checking MySQL readiness..."
-  
-  # Set MySQL auth based on .env (single source of truth)
-  MYSQL_ROOT_PASSWORD=$(grep -E '^MYSQL_ROOT_PASSWORD=' "$PROJECT_ROOT_DIR/.env" 2>/dev/null | cut -d'=' -f2 | tr -d '"' | xargs || true)
-  MYSQL_ROOT_PASSWORD="${MYSQL_ROOT_PASSWORD:-root}"
-  MYSQL_AUTH="-uroot -p${MYSQL_ROOT_PASSWORD}"
-  echo_info "Using MySQL root password from .env"
-  
-  while true; do
-    # Test the MySQL connection with the detected authentication
-    if docker-compose "${COMPOSE_FILES[@]}" exec -T cafedebugdb mysql $MYSQL_AUTH -e "SELECT 1" >/dev/null 2>&1; then
-      echo_ok "MySQL is ready and accessible."
-      break
+echo_info "Waiting for MySQL to complete initialization (this may take 1-2 minutes)..."
+
+MAX_WAIT=180
+WAITED=0
+echo "Checking MySQL readiness..."
+
+MYSQL_ROOT_PASSWORD="$(get_env_value "MYSQL_ROOT_PASSWORD" || echo "root")"
+MYSQL_AUTH="-uroot -p${MYSQL_ROOT_PASSWORD}"
+echo_info "Using MySQL root password from .env"
+
+while true; do
+    if compose exec -T cafedebugdb mysql ${MYSQL_AUTH} -e "SELECT 1" >/dev/null 2>&1; then
+        echo_ok "MySQL is ready and accessible."
+        break
     fi
-    
-    # Check if MySQL is still initializing by looking for the "ready for connections" message
+
     if docker logs cafedebugdb 2>&1 | tail -10 | grep -q "ready for connections.*port: 3306"; then
-      echo_info "MySQL reports ready, but connection test failed. Waiting a bit more..."
-      sleep 5
+        echo_info "MySQL reports ready, but connection test failed. Waiting a bit more..."
+        sleep 5
     else
-      echo_info "MySQL still initializing... ($WAITED/$MAX_WAIT seconds)"
+        echo_info "MySQL still initializing... (${WAITED}/${MAX_WAIT} seconds)"
     fi
-    
+
     sleep 5
-    WAITED=$((WAITED+5))
-    if [ "$WAITED" -ge "$MAX_WAIT" ]; then
-      echo_error "Timed out waiting for MySQL to become ready. Logs:"
-      docker logs cafedebugdb --tail=50
-      echo_error "Attempted MySQL auth: $MYSQL_AUTH"
-      exit 1
+    WAITED=$((WAITED + 5))
+    if [ "${WAITED}" -ge "${MAX_WAIT}" ]; then
+        echo_error "Timed out waiting for MySQL to become ready. Logs:"
+        docker logs cafedebugdb --tail=50
+        echo_error "Attempted MySQL auth: ${MYSQL_AUTH}"
+        exit 1
     fi
-  done
-  
-  # Give MySQL a few more seconds to fully stabilize
-  echo_info "MySQL is ready. Waiting additional 10 seconds for full stabilization..."
-  sleep 10
+done
 
-  # Resolve the container id for the service (use docker-compose ps -q)
-  CID=$(docker-compose "${COMPOSE_FILES[@]}" ps -q cafedebugdb || true)
-  if [ -z "${CID:-}" ]; then
-    echo_warning "Warning: could not determine container id for cafedebugdb; falling back to service name"
-    CID="cafedebugdb"
-  fi
+echo_info "MySQL is ready. Waiting additional 10 seconds for full stabilization..."
+sleep 10
 
-  # Helper functions for MySQL operations using detected auth
-  run_mysql_cmd() {
-    # $1 is the SQL statement to run non-interactively
-    docker exec "${CID}" /usr/bin/mysql ${MYSQL_AUTH} -e "$1"
-  }
+# Use docker compose exec (not docker exec with /usr/bin/mysql) so Git Bash on
+# Windows does not rewrite container paths to C:/Program Files/Git/...
+run_mysql_cmd() {
+    compose exec -T cafedebugdb mysql ${MYSQL_AUTH} -e "$1"
+}
 
-  run_mysql_stdin() {
-    # pipes stdin into mysql for the target database passed as first arg
+run_mysql_stdin() {
     local target_db="${1:-}"
-    docker exec -i "${CID}" /usr/bin/mysql ${MYSQL_AUTH} "${target_db}"
-  }
+    compose exec -T cafedebugdb mysql ${MYSQL_AUTH} "${target_db}"
+}
 
-  # Ensure the target database exists
-  echo_info "Ensuring target database exists (cafedebug-mysql-local)..."
-  CREATE_DB_SQL='CREATE DATABASE IF NOT EXISTS `cafedebug-mysql-local` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;'
+echo_info "Ensuring target database exists (cafedebug-mysql-local)..."
+CREATE_DB_SQL='CREATE DATABASE IF NOT EXISTS `cafedebug-mysql-local` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;'
+run_mysql_cmd "${CREATE_DB_SQL}"
+echo_ok "Database ensured."
 
-  run_mysql_cmd "$CREATE_DB_SQL"
-  echo_ok "Database ensured."
+SQL_CREATE_PATH="${PROJECT_ROOT_DIR}/database/mysql/cafedebugdb/cafedebug-mysql-create-table.sql"
+SQL_INSERT_PATH="${PROJECT_ROOT_DIR}/database/mysql/cafedebugdb/cafedebug-mysql-insert.sql"
 
-  # Paths to the SQL files from the project root
-  SQL_CREATE_PATH="$PROJECT_ROOT_DIR/database/mysql/cafedebugdb/cafedebug-mysql-create-table.sql"
-  SQL_INSERT_PATH="$PROJECT_ROOT_DIR/database/mysql/cafedebugdb/cafedebug-mysql-insert.sql"
-
-  # Execute the create and insert scripts
-  echo_info "Applying SQL create script..."
-  if [ -f "$SQL_CREATE_PATH" ]; then
-    cat "$SQL_CREATE_PATH" | run_mysql_stdin cafedebug-mysql-local
+echo_info "Applying SQL create script..."
+if [ -f "${SQL_CREATE_PATH}" ]; then
+    cat "${SQL_CREATE_PATH}" | run_mysql_stdin cafedebug-mysql-local
     echo_ok "Create script applied successfully"
-  else
-    echo_error "Create script not found at $SQL_CREATE_PATH"
+else
+    echo_error "Create script not found at ${SQL_CREATE_PATH}"
     exit 1
-  fi
+fi
 
-  echo_info "Applying SQL insert script..."
-  if [ -f "$SQL_INSERT_PATH" ]; then
-    cat "$SQL_INSERT_PATH" | run_mysql_stdin cafedebug-mysql-local
+echo_info "Applying SQL insert script..."
+if [ -f "${SQL_INSERT_PATH}" ]; then
+    cat "${SQL_INSERT_PATH}" | run_mysql_stdin cafedebug-mysql-local
     echo_ok "Insert script applied successfully"
-  else
-    echo_error "Insert script not found at $SQL_INSERT_PATH"
+else
+    echo_error "Insert script not found at ${SQL_INSERT_PATH}"
     exit 1
-  fi
-  
-  # Ensure Minio buckets exist (delegates to scripts/create-minio-buckets.sh)
-  echo_info "Ensuring Minio buckets..."
-  DEFAULT_BUCKETS=("cafedebug-uploads" "cafedebug-images")
-  if [ -x "$PROJECT_ROOT_DIR/scripts/create-minio-buckets.sh" ]; then
+fi
+
+echo_info "Ensuring Minio buckets..."
+DEFAULT_BUCKETS=("cafedebug-uploads" "cafedebug-images")
+MINIO_BUCKETS_SCRIPT="${PROJECT_ROOT_DIR}/scripts/create-minio-buckets.sh"
+if [ -f "${MINIO_BUCKETS_SCRIPT}" ]; then
     if [ -n "${MINIO_BUCKETS:-}" ]; then
-      IFS=',' read -r -a _buckets <<< "${MINIO_BUCKETS}"
-      "$PROJECT_ROOT_DIR/scripts/create-minio-buckets.sh" "${_buckets[@]}"
+        IFS=',' read -r -a _buckets <<< "${MINIO_BUCKETS}"
+        bash "${MINIO_BUCKETS_SCRIPT}" "${_buckets[@]}"
     else
-      "$PROJECT_ROOT_DIR/scripts/create-minio-buckets.sh" "${DEFAULT_BUCKETS[@]}"
+        bash "${MINIO_BUCKETS_SCRIPT}" "${DEFAULT_BUCKETS[@]}"
     fi
-  else
-    echo_warning "Warning: create-minio-buckets.sh not found or not executable at $PROJECT_ROOT_DIR/scripts/; skipping bucket creation"
-  fi
+else
+    echo_warning "Warning: create-minio-buckets.sh not found at ${MINIO_BUCKETS_SCRIPT}; skipping bucket creation"
+fi
 
-  API_ENABLED=$(grep -E '^CAFEDEBUG_API_ENABLED=' "$PROJECT_ROOT_DIR/.env" 2>/dev/null | cut -d'=' -f2 | tr -d '"' | xargs || echo "true")
-  API_ENABLED="${API_ENABLED:-true}"
-  API_ENABLED_LOWER=$(echo "$API_ENABLED" | tr '[:upper:]' '[:lower:]')
+API_ENABLED="$(get_env_value "CAFEDEBUG_API_ENABLED" || echo "true")"
+API_ENABLED_LOWER="$(printf '%s' "${API_ENABLED}" | tr '[:upper:]' '[:lower:]')"
 
-  if [ "$API_ENABLED_LOWER" = "false" ]; then
+if [ "${API_ENABLED_LOWER}" = "false" ]; then
     echo_info "CAFEDEBUG_API_ENABLED=false — skipping API startup."
     exit 0
-  fi
+fi
 
-  echo_info "Starting CafeDebug API after DB seed..."
-  docker-compose "${COMPOSE_FILES[@]}" up -d cafedebug-api
+echo_info "Starting CafeDebug API after DB seed..."
+compose up -d cafedebug-api
 
-  # Wait for CafeDebug API to be healthy
-  API_PORT=$(grep -E '^CAFEDEBUG_API_PORT=' "$PROJECT_ROOT_DIR/.env" 2>/dev/null | cut -d'=' -f2 | tr -d '"' | xargs || echo "8080")
-  API_PORT="${API_PORT:-8080}"
-  echo_info "Waiting for cafedebug-backend.api API on port $API_PORT..."
-  API_MAX_WAIT=120
-  API_WAITED=0
-  until curl -fsS --max-time 3 "http://localhost:${API_PORT}/health" >/dev/null 2>&1; do
+API_PORT="$(get_env_value "CAFEDEBUG_API_PORT" || echo "8080")"
+echo_info "Waiting for cafedebug-backend.api API on port ${API_PORT}..."
+API_MAX_WAIT=120
+API_WAITED=0
+until curl -fsS --max-time 3 "http://localhost:${API_PORT}/health" >/dev/null 2>&1; do
     sleep 5
     API_WAITED=$((API_WAITED + 5))
-    if [ "$API_WAITED" -ge "$API_MAX_WAIT" ]; then
-      echo_warning "CafeDebug API did not become healthy within ${API_MAX_WAIT}s — check logs: docker logs cafedebug-backend.api"
-      break
+    if [ "${API_WAITED}" -ge "${API_MAX_WAIT}" ]; then
+        echo_warning "CafeDebug API did not become healthy within ${API_MAX_WAIT}s — check logs: docker logs cafedebug-backend.api"
+        break
     fi
-    echo_info "API not ready yet... ($API_WAITED/${API_MAX_WAIT}s)"
-  done
-  if curl -fsS --max-time 3 "http://localhost:${API_PORT}/health" >/dev/null 2>&1; then
+    echo_info "API not ready yet... (${API_WAITED}/${API_MAX_WAIT}s)"
+done
+if curl -fsS --max-time 3 "http://localhost:${API_PORT}/health" >/dev/null 2>&1; then
     echo_ok "CafeDebug API is healthy at http://localhost:${API_PORT}"
-  fi
+fi

--- a/scripts/clear-setup.sh
+++ b/scripts/clear-setup.sh
@@ -1,36 +1,27 @@
 #!/bin/bash
+set -euo pipefail
 
-# Source functions for colored output and utilities
-SCRIPT_DIR="$(dirname "$0")"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/functions.sh"
 
-# Define the root directory of the project (one level up from the script directory)
-PROJECT_ROOT_DIR="$(dirname "$0")/.."
+init_script_paths "${BASH_SOURCE[0]}"
+resolve_compose_cmd || exit 1
+build_compose_files
 
-# Source functions for colored output and utilities
-SCRIPT_DIR="$(dirname "$0")"
-source "${SCRIPT_DIR}/functions.sh"
-
-if question "Do you want only stop the containers?"; then
-    echo_warning "Stopping all docker-compose services..."
-    docker-compose -f "$PROJECT_ROOT_DIR/docker-compose.yml" down
-    echo_ok "Containers stopped successfully!"
-else
-    if question "Do you want remove all the containers and images?"; then
-        echo_warning "Removing all containers, images, and volumes..."
-        docker-compose -f "$PROJECT_ROOT_DIR/docker-compose.yml" down -v --rmi all
-        
-        if question "Do you want to execute 'docker system prune -a' to clear all?"; then
-            echo_warning "Running docker system prune -a --volumes..."
-            docker system prune -a --volumes
-            echo_ok "Complete system cleanup finished!"
-        else
-            echo_ok "Containers and images removed!"
-        fi
-    else
-        echo_info "No action taken."
-    fi
+if question "Stop all containers? (volumes and data are kept)"; then
+    echo_warning "Stopping containers..."
+    compose down
+    echo_ok "Containers stopped. Volumes and data were kept."
+    echo "Done. Run './devstack -up' when you want to start again."
+    exit 0
 fi
 
-echo "Docker environment cleaned. Ready for a fresh setup!"
+if question "Remove containers, volumes, and images?"; then
+    echo_warning "Removing containers, volumes, and images..."
+    compose down -v --rmi all
+    echo_ok "Containers, volumes, and images removed."
+    echo "Done. Run './devstack -up' when you want to start again."
+    exit 0
+fi
 
+echo_info "Teardown cancelled. No changes made."

--- a/scripts/create-minio-buckets.sh
+++ b/scripts/create-minio-buckets.sh
@@ -1,45 +1,40 @@
 #!/bin/bash
 set -euo pipefail
 
-# Source functions for colored output and utilities
-SCRIPT_DIR="$(dirname "$0")"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/functions.sh"
 
-PROJECT_ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
-COMPOSE_FILES=("-f" "$PROJECT_ROOT_DIR/docker-compose.yml")
+init_script_paths "${BASH_SOURCE[0]}"
+resolve_compose_cmd || exit 1
+build_compose_files
 
-# Start minio service (if not already)
 echo_info "Starting Minio (detached)..."
-docker-compose "${COMPOSE_FILES[@]}" up -d minio
+compose up -d minio
 
-# wait a bit for minio to be ready
 echo "Waiting for Minio to be ready..."
 sleep 5
 
-# Create buckets using minio client container
-# We override entrypoint to run mc commands
-# Buckets can be passed as arguments or via MINIO_BUCKETS env (comma-separated)
 if [ "$#" -gt 0 ]; then
-     BUCKETS=("$@")
+    BUCKETS=("$@")
 elif [ -n "${MINIO_BUCKETS:-}" ]; then
-     IFS=',' read -r -a BUCKETS <<< "${MINIO_BUCKETS}"
+    IFS=',' read -r -a BUCKETS <<< "${MINIO_BUCKETS}"
 else
-     # default bucket for this project (changed per request)
-     BUCKETS=("cafedebug-uploads" "cafedebug-images")
+    BUCKETS=("cafedebug-uploads" "cafedebug-images")
 fi
 
-MC_CMDS=("mc --insecure alias set myminio http://minio:9000 \${MINIO_ROOT_USER:-minioadmin} \${MINIO_ROOT_PASSWORD:-minioadmin}")
+MINIO_ROOT_USER="$(get_env_value "MINIO_ROOT_USER" || echo "minioadmin")"
+MINIO_ROOT_PASSWORD="$(get_env_value "MINIO_ROOT_PASSWORD" || echo "minioadmin")"
+
+MC_CMDS=("mc --insecure alias set myminio http://minio:9000 ${MINIO_ROOT_USER} ${MINIO_ROOT_PASSWORD}")
 for b in "${BUCKETS[@]}"; do
-     # create the bucket only if it does not already exist (idempotent)
-     MC_CMDS+=("mc --insecure ls myminio/${b} >/dev/null 2>&1 || mc --insecure mb myminio/${b}")
-     # local-dev default: make uploaded files publicly readable
-     MC_CMDS+=("mc --insecure anonymous set download myminio/${b}")
+    MC_CMDS+=("mc --insecure ls myminio/${b} >/dev/null 2>&1 || mc --insecure mb myminio/${b}")
+    MC_CMDS+=("mc --insecure anonymous set download myminio/${b}")
 done
 MC_CMDS+=("mc --insecure ls myminio")
 
 CMD=$(IFS=' && '; echo "${MC_CMDS[*]}")
 
 echo_info "Running minio-mc to create buckets: ${BUCKETS[*]}"
-docker-compose "${COMPOSE_FILES[@]}" run --rm --entrypoint /bin/sh minio-mc -c "$CMD"
+compose run --rm --entrypoint sh minio-mc -c "${CMD}"
 
-echo_info "Buckets ensured. You can open Minio Console at http://localhost:9001 (user: minioadmin / pass: minioadmin)"
+echo_info "Buckets ensured. You can open Minio Console at http://localhost:9001 (user: ${MINIO_ROOT_USER} / pass: ${MINIO_ROOT_PASSWORD})"

--- a/scripts/data-generator.sh
+++ b/scripts/data-generator.sh
@@ -1,15 +1,16 @@
 #!/bin/bash
+set -euo pipefail
 
-# Define the root directory of the project (one level up from the script directory)
-PROJECT_ROOT_DIR="$(dirname "$0")/.."
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/functions.sh"
+
+init_script_paths "${BASH_SOURCE[0]}"
 
 echo "..:: Do you want to generate test data? (Y/N) ::.."
-read -p "Answer: " -n 1 -r
+read -r -p "Answer: " -n 1 REPLY
 echo
 
-if [[ "$REPLY" =~ ^[Yy]$ ]]; then
-    
-    # generate data users
+if [[ "${REPLY}" =~ ^[Yy]$ ]]; then
     users=(
         '{
             "firstName": "John", 
@@ -53,22 +54,31 @@ if [[ "$REPLY" =~ ^[Yy]$ ]]; then
             "country": "BRA",
             "creditCardNumber": "7789-5678-1163-5890"
         }'
+        '{
+            "firstName": "Khaled",
+            "secondName": "Al jadaan",
+            "email": "Khaled.aljadaan@gmail.com", 
+            "age": 33,
+            "password": "TestPassword123!",
+            "phoneNumber": "+966567788990", 
+            "address": "Rua das Flores, 123", 
+            "city": "Riyadh", 
+            "state": "Riyadh", 
+            "zipCode": "11441", 
+            "country": "SAU",
+            "creditCardNumber": "1234-5678-1234-5678"
+        }'
     )
 
-    #directory to store json file
-    JSON_DIR="$PROJECT_ROOT_DIR/data/users"
+    JSON_DIR="${PROJECT_ROOT_DIR}/data/users"
+    mkdir -p "${JSON_DIR}"
 
-    #create directory if not exists
-    mkdir -p "$JSON_DIR"
-
-    # generate json file for each user
     for ((i=0; i<${#users[@]}; i++)); do
-        echo "${users[i]}" > "$JSON_DIR/user_$i.json"
-        echo "Generated: $JSON_DIR/user_$i.json"
+        printf '%s\n' "${users[i]}" > "${JSON_DIR}/user_${i}.json"
+        echo "Generated: ${JSON_DIR}/user_${i}.json"
     done
 
     echo "User data generation complete!"
 else
     echo "User opted not to generate data. Exiting."
 fi
-# deixar genérico incluir dados do cartão e banco para massa de dados para teste

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -19,7 +19,8 @@ TITLE_COUNTER=0
 SUBTITLE_COUNTER=0
 function title(){
     ((++TITLE_COUNTER))
-    ((SUBTITLE_COUNTER=0))
+    # Plain assignment — ((SUBTITLE_COUNTER=0)) exits 1 under set -e and kills status/doctor silently.
+    SUBTITLE_COUNTER=0
     if [ ${TITLE_COUNTER} == 1 ]
     then
         echo "${COLOR_TITLE}${TITLE_COUNTER}. $*${COLOR_NORMAL}"
@@ -50,16 +51,13 @@ function echo_warning() {
 }
 
 function question(){
+    local prompt="$1"
+    local reply=""
+
     echo ""
-    echo $1
-    echo -n "${COLOR_GREEN}[Yy] Yes${COLOR_NORMAL} / ${COLOR_RED}[Nn] No${COLOR_NORMAL}"
-    read -r REPLY
-    echo ""
-    if [[ $REPLY =~ ^([Yy]|[Yy][Ee][Ss])$ ]]
-    then 
-        return 0
-    fi
-    false
+    echo "${prompt}"
+    read -r -p "Type y or n: " reply
+    [[ "${reply}" =~ ^([Yy]|[Yy][Ee][Ss])$ ]]
 }
 
 function check_image_exists(){
@@ -69,4 +67,65 @@ function check_image_exists(){
     else
         return 1
     fi
+}
+
+# Resolve absolute script/project paths (works on Linux, macOS, and Git Bash on Windows).
+init_script_paths() {
+    local script_path="$1"
+    SCRIPT_DIR="$(cd "$(dirname "${script_path}")" && pwd)"
+    PROJECT_ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+    ENV_FILE="${PROJECT_ROOT_DIR}/.env"
+}
+
+# Read a key from .env without relying on xargs (portable across shells/OSes).
+get_env_value() {
+    local key="$1"
+    local line value
+
+    if [ ! -f "${ENV_FILE}" ]; then
+        return 1
+    fi
+
+    line="$(grep -E "^[[:space:]]*${key}[[:space:]]*=" "${ENV_FILE}" | tail -n 1 || true)"
+    if [ -z "${line}" ]; then
+        return 1
+    fi
+
+    value="${line#*=}"
+    value="$(printf '%s' "${value}" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+    value="${value%\"}"
+    value="${value#\"}"
+    value="${value%\'}"
+    value="${value#\'}"
+
+    if [ -z "${value}" ]; then
+        return 1
+    fi
+
+    printf '%s\n' "${value}"
+}
+
+# Prefer Docker Compose v2 plugin, fall back to docker-compose v1 binary.
+resolve_compose_cmd() {
+    if docker compose version >/dev/null 2>&1; then
+        COMPOSE_CMD=(docker compose)
+        return 0
+    fi
+
+    if command -v docker-compose >/dev/null 2>&1; then
+        COMPOSE_CMD=(docker-compose)
+        return 0
+    fi
+
+    echo_error "Error: Docker Compose is not available (docker compose / docker-compose)."
+    return 1
+}
+
+# Root compose file is the single source of truth for this repo.
+build_compose_files() {
+    COMPOSE_FILES=("-f" "${PROJECT_ROOT_DIR}/docker-compose.yml")
+}
+
+compose() {
+    "${COMPOSE_CMD[@]}" "${COMPOSE_FILES[@]}" "$@"
 }

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -111,6 +111,51 @@ is_service_running() {
     [ "${status}" = "running" ]
 }
 
+# Report long-running services as running; minio-mc is a one-shot job (exited 0 = OK).
+check_core_service() {
+    local service="$1"
+    local strict="${2:-0}"
+    local cid status exit_code
+
+    cid="$(compose ps -aq "${service}" 2>/dev/null | head -n 1 || true)"
+    if [ -z "${cid}" ]; then
+        if [ "${strict}" -eq 1 ]; then
+            echo_error "${service}: not started"
+            return 1
+        fi
+        echo_warning "${service}: not running"
+        return 1
+    fi
+
+    status="$(docker inspect -f '{{.State.Status}}' "${cid}" 2>/dev/null || true)"
+
+    if [ "${status}" = "running" ]; then
+        echo_ok "${service}: running"
+        return 0
+    fi
+
+    if [ "${service}" = "minio-mc" ] && [ "${status}" = "exited" ]; then
+        exit_code="$(docker inspect -f '{{.State.ExitCode}}' "${cid}" 2>/dev/null || echo 1)"
+        if [ "${exit_code}" = "0" ]; then
+            echo_ok "${service}: completed (one-shot)"
+            return 0
+        fi
+        if [ "${strict}" -eq 1 ]; then
+            echo_error "${service}: exited with code ${exit_code}"
+            return 1
+        fi
+        echo_warning "${service}: exited with code ${exit_code}"
+        return 1
+    fi
+
+    if [ "${strict}" -eq 1 ]; then
+        echo_error "${service}: ${status}"
+        return 1
+    fi
+    echo_warning "${service}: ${status}"
+    return 1
+}
+
 detect_mysql_auth() {
     local mysql_root_password
     mysql_root_password="$(get_env_value "MYSQL_ROOT_PASSWORD" || echo "root")"
@@ -137,11 +182,7 @@ status_cmd() {
 
     subtitle "Core services"
     for service in cafedebugdb minio minio-mc cafedebug-api; do
-        if is_service_running "${service}"; then
-            echo_ok "${service}: running"
-        else
-            echo_warning "${service}: not running"
-        fi
+        check_core_service "${service}" 0 || true
     done
 
     subtitle "Quick checks"
@@ -211,10 +252,7 @@ doctor_cmd() {
 
     subtitle "Service runtime"
     for service in cafedebugdb minio minio-mc cafedebug-api; do
-        if is_service_running "${service}"; then
-            echo_ok "${service}: running"
-        else
-            echo_error "${service}: not running"
+        if ! check_core_service "${service}" 1; then
             failed=1
         fi
     done


### PR DESCRIPTION
## Summary

Hardens the devstack shell scripts for cross-platform use on **Windows (Git Bash/WSL), macOS, and Linux**. Fixes silent failures in `status`/`doctor`, improves teardown prompts, and standardizes Docker Compose usage across setup scripts.

## Changes

### Cross-platform script infrastructure
- Added shared helpers in `scripts/functions.sh`:
  - `init_script_paths`, `get_env_value`, `resolve_compose_cmd`, `compose`, `build_compose_files`
- Supports both **Docker Compose v2** (`docker compose`) and v1 (`docker-compose`)
- Uses `BASH_SOURCE` and absolute paths so scripts work from any directory
- Invokes sub-scripts with `bash` instead of relying on executable bits (fixes Windows)

### Setup & teardown
- **`cafedebug-setup.sh`**: starts API only after DB seed; uses portable `.env` parsing
- **`clear-setup.sh`**: simple two-step **y/n** teardown flow; uses shared compose helper
- **`create-minio-buckets.sh`** / **`data-generator.sh`**: aligned with shared helpers and safer defaults

### Diagnostics
- **`run.sh`**: fixes silent exit in `status` and `doctor` caused by `set -e` + `title()`
- Treats `minio-mc` as a **one-shot** container (`completed`) instead of reporting a false failure

### Repo hygiene
- **`.gitattributes`**: enforces LF line endings for `*.sh` (prevents shebang failures on Mac/Linux)
- **`docker-compose.yml`**: removes deprecated top-level `version` key

## Test plan

- [x] `./devstack -up` — MySQL seeded, MinIO buckets created, API healthy at `http://localhost:8080`
- [x] `./devstack status` — shows service status and health checks
- [x] `./devstack doctor` — reports **All checks passed**
- [x] `./devstack -d` — clear y/n prompts; containers stop cleanly
- [x] Re-run `./devstack -up` after teardown — environment comes back up successfully
- [ ] Verify on macOS
- [ ] Verify on Linux
- [ ] Verify on another Windows machine (Git Bash)

## Notes

- Requires **Docker** + **Bash** (Git Bash or WSL on Windows)
- `minio-mc: completed (one-shot)` is expected — it exits after bucket setup
- Local changes to `cafedebug-mysql-insert.sql` were intentionally **not** included in this PR